### PR TITLE
deps: Makes gem compatible with Ruby 3

### DIFF
--- a/lib/packagecloud/client.rb
+++ b/lib/packagecloud/client.rb
@@ -1,4 +1,4 @@
-require 'multi_json'
+require 'json'
 require 'mime'
 require 'excon'
 require 'packagecloud/result'
@@ -277,7 +277,7 @@ module Packagecloud
 
       # returns the parsed body of a successful result
       def parsed_json_result(response)
-        prepare_result(response) { |result| result.response = MultiJson.load(response.data[:body]) }
+        prepare_result(response) { |result| result.response = JSON.parse(response.data[:body]) }
       end
 
       def prepare_result(response)

--- a/lib/packagecloud/version.rb
+++ b/lib/packagecloud/version.rb
@@ -1,7 +1,7 @@
 module Packagecloud
   MAJOR_VERSION = "1"
-  MINOR_VERSION = "0"
-  PATCH_VERSION = "9"
+  MINOR_VERSION = "1"
+  PATCH_VERSION = "0"
 
   VERSION = [MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION].join(".")
 end

--- a/packagecloud-ruby.gemspec
+++ b/packagecloud-ruby.gemspec
@@ -19,10 +19,9 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'excon', '~> 0.40'
   gem.add_runtime_dependency 'json_pure', '~> 2'
-  gem.add_runtime_dependency 'multi_json', '~> 1.0'
   gem.add_runtime_dependency 'mime', '~> 0.4'
 
-  gem.add_development_dependency 'bundler', '~> 1.0'
+  gem.add_development_dependency 'bundler', '~> 2.0'
   gem.add_development_dependency 'rake', '~> 0.8'
   gem.add_development_dependency 'rspec', '~> 2.4'
   gem.add_development_dependency 'simplecov', '~> 0.9'


### PR DESCRIPTION
```
docker run --rm -it -v $PWD:/app --workdir /app --entrypoint bash ruby:3.0

root@ccefb916ee27:/app# bundle install && bundle exec rspec
Fetching gem metadata from https://rubygems.org/...
Fetching rake 0.9.6
Installing rake 0.9.6
Using bundler 2.2.33
Fetching docile 1.4.0
Fetching excon 0.97.0
Fetching io-console 0.6.0
Fetching diff-lcs 1.5.0
Installing docile 1.4.0
Installing io-console 0.6.0 with native extensions
Fetching json_pure 2.6.3
Installing diff-lcs 1.5.0
Installing excon 0.97.0
Fetching mime 0.4.4
Fetching rspec-core 2.99.2
Installing json_pure 2.6.3
Fetching rspec-mocks 2.99.4
Installing mime 0.4.4
Fetching simplecov-html 0.12.3
Installing rspec-core 2.99.2
Installing rspec-mocks 2.99.4
Fetching simplecov_json_formatter 0.1.4
Fetching webrick 1.7.0
Installing simplecov-html 0.12.3
Fetching rspec-expectations 2.99.2
Installing simplecov_json_formatter 0.1.4
Using packagecloud-ruby 1.1.0 from source at `.`
Fetching simplecov 0.22.0
Installing webrick 1.7.0
Fetching yard 0.9.28
Installing rspec-expectations 2.99.2
Installing simplecov 0.22.0
Fetching rspec 2.99.0
Installing rspec 2.99.0
Installing yard 0.9.28
Fetching reline 0.3.2
Installing reline 0.3.2
Fetching irb 1.6.2
Installing irb 1.6.2
Fetching rubygems-tasks 0.2.5
Installing rubygems-tasks 0.2.5
Bundle complete! 7 Gemfile dependencies, 21 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
waiting for server to start...
[2023-01-10 12:22:50] INFO  WEBrick 1.7.0
[2023-01-10 12:22:50] INFO  ruby 3.0.5 (2022-11-24) [aarch64-linux]
waiting for server to start...

Packagecloud::Package
[2023-01-10 12:22:50] INFO  WEBrick::HTTPServer#start: pid=61 port=8000
  should raise for nil file
  should raise for file that doesn't exist
  should be able to open String file paths
  should be able to open File objects
  should raise if IO object is passed without filename
  should handle IO object if passed with filename
  should handle source_files options
  should always have a {} as default for source files

Packagecloud
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
  should have a VERSION constant
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
  GET api/v1/distributions.json
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "POST /api/v1/repos/joedamato/test_repo/packages.json HTTP/1.1" 201 2
- -> /api/v1/repos/joedamato/test_repo/packages.json
  POST debian package /api/v1/repos/joedamato/test_repo/packages.json
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "POST /api/v1/repos/joedamato/test_repo/packages.json HTTP/1.1" 201 2
- -> /api/v1/repos/joedamato/test_repo/packages.json
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "POST /api/v1/repos/joedamato/test_repo/packages.json HTTP/1.1" 201 2
- -> /api/v1/repos/joedamato/test_repo/packages.json
  POST debian package /api/v1/repos/joedamato/test_repo/packages.json twice
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "POST /api/v1/repos/joedamato/test_repo/packages.json HTTP/1.1" 201 2
- -> /api/v1/repos/joedamato/test_repo/packages.json
  POST gem package /api/v1/repos/joedamato/test_repo/packages.json
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "POST /api/v1/repos/joedamato/test_repo/packages.json HTTP/1.1" 201 2
- -> /api/v1/repos/joedamato/test_repo/packages.json
  POST debian package /api/v1/repos/joedamato/test_repo/packages.json with string distro_version_id
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "POST /api/v1/repos/joedamato/test_repo/packages.json HTTP/1.1" 201 2
- -> /api/v1/repos/joedamato/test_repo/packages.json
  POST source package /api/v1/repos/joedamato/test_repo/packages.json
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "POST /api/v1/repos/joedamato/test_repo/packages/contents.json HTTP/1.1" 200 200
- -> /api/v1/repos/joedamato/test_repo/packages/contents.json
  POST /api/v1/repos/joedamato/test_repo/packages/contents.json
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/gem_version.json HTTP/1.1" 200 37
- -> /api/v1/gem_version.json
  GET /api/v1/gem_version.json
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/repos.json HTTP/1.1" 200 241
- -> /api/v1/repos.json
  GET /api/v1/repos.json
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "POST /api/v1/repos.json HTTP/1.1" 200 2
- -> /api/v1/repos.json
  POST /api/v1/repos.json
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/repos/joedamato/test_repo.json HTTP/1.1" 200 239
- -> /api/v1/repos/joedamato/test_repo.json
  GET /api/v1/repos/joedamato/test_repo.json
  should raise if the repo name is invalid
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/repos/joedamato/invalid_repo.json HTTP/1.1" 404 4
- -> /api/v1/repos/joedamato/invalid_repo.json
  GET /api/v1/repos/joedamato/invalid_repo.json (invalid repo)
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
  should have a distinct User-Agent that includes the version
- -> /api/v1/distributions.json
  should raise if the username has an @ in it
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 401 30
- -> /api/v1/distributions.json
  invalid credentials should raise unauthenticated exception
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "DELETE /api/v1/repos/joedamato/test_repo/master_tokens/test_master_token/read_tokens/1 HTTP/1.1" 204 0
- -> /api/v1/repos/joedamato/test_repo/master_tokens/test_master_token/read_tokens/1
  deletes read token
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "DELETE /api/v1/repos/joedamato/test_repo/master_tokens/test_master_token/read_tokens/2323 HTTP/1.1" 404 4
- -> /api/v1/repos/joedamato/test_repo/master_tokens/test_master_token/read_tokens/2323
  fails to delete invalid read token
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/repos/joedamato/test_repo/master_tokens/test_master_token/read_tokens.json HTTP/1.1" 200 64
- -> /api/v1/repos/joedamato/test_repo/master_tokens/test_master_token/read_tokens.json
  lists read tokens
  timeouts
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
    should have defaults
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
    should respect passed values
  find_distribution_id
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
    should find ubuntu/breezy
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
    should find just breezy
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
    should find python
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
    should find node
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
    should return nil for invalid distro
127.0.0.1 - - [10/Jan/2023:12:22:50 UTC] "GET /api/v1/distributions.json HTTP/1.1" 200 13967
- -> /api/v1/distributions.json
    should raise for amiguous distro queries

Finished in 0.0873 seconds
36 examples, 0 failures
Coverage report generated for RSpec to /app/coverage. 453 / 471 LOC (96.18%) covered.
[2023-01-10 12:22:50] INFO  going to shutdown ...
[2023-01-10 12:22:50] INFO  WEBrick::HTTPServer#start done.
```